### PR TITLE
Improve chat box layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -96,7 +96,9 @@ button:hover {
 .chat-box {
     display: flex;
     flex-direction: column;
-    height: 300px;
+    /* Allow the chat box to grow while ensuring a reasonable minimum */
+    min-height: 500px;
+    height: auto;
     overflow-y: auto;
     border: 1px solid #ddd;
     padding: 10px;


### PR DESCRIPTION
## Summary
- tweak `.chat-box` CSS to allow taller content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683be4f4aef88333b2302be29f5b39b5